### PR TITLE
Fix grammar

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -346,7 +346,7 @@ Potentially ill-formed UTF-16</h2>
   A sequence of <a>16-bit code units</a> is <dfn>potentially ill-formed UTF-16</dfn>
   if it is intended to be interpreted as <a>UTF-16</a>,
   but is not necessarily <a>well-formed</a> in <a>UTF-16</a>.
-  It effectively encodes a sequence of <a>code point</a>
+  It effectively encodes a sequence of <a>code points</a>
   that do not contain any <a>surrogate code point pair</a>.
 
   Note: Like <a>UTF-16</a>,


### PR DESCRIPTION
"code points" should be plural here.